### PR TITLE
Add parameters to cloud run service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build-functions: check-env
 
 build-cloudrun:
 	@echo "Building cloud run service..."
-	gcloud builds submit --tag gcr.io/doc-template-front-dev/doc-generator cloud-run/.
+	gcloud builds submit --tag gcr.io/${DEV_PROJECT}/doc-generator cloud-run/.
 
 # Deployment commands
 .PHONY: deploy-prod deploy-dev deploy-functions deploy-rules deploy-cloudrun
@@ -87,15 +87,16 @@ deploy-rules:
 	@echo " Deploying firestore rules..."
 	${FIREBASE} deploy --only firestore:rules
 
-deploy-cloudrun:
+deploy-cloudrun: build-cloudrun
 	@echo " Deploying cloud run service..."
 	gcloud run deploy doc-generator \
-	--image=gcr.io/doc-template-front-dev/doc-generator \
-	--service-account=doc-generator-sa@doc-template-front-dev.iam.gserviceaccount.com \
-	--update-env-vars="JAVA_TOOL_OPTIONS=-Djava.awt.headless=true" \
+	--image=gcr.io/${DEV_PROJECT}/doc-generator \
+	--service-account=${SA_DOC_GENERATOR_DEV} \
 	--no-allow-unauthenticated \
 	--platform=managed \
-	--region=us-central1
+	--region=us-central1 \
+	--set-env-vars="JAVA_TOOL_OPTIONS=-Djava.awt.headless=true" \
+	--set-env-vars=OUTPUT_BUCKET=${DOC_TEMPLATE_FIREBASE_BUCKET_DEV}
 
 # Serve locally
 .PHONY: serve-prod serve-dev serve-dev-emulators

--- a/docs/readme/howto/README.md
+++ b/docs/readme/howto/README.md
@@ -1,3 +1,4 @@
 # How to section
 
 1. [Create system admin / first user](./how-to-create-system-admin-user/README.md)
+1. [Create cloudrun service account](./how-to-create-cloudrun-service-account/README.md)

--- a/docs/readme/howto/how-to-create-cloudrun-service-account/README.md
+++ b/docs/readme/howto/how-to-create-cloudrun-service-account/README.md
@@ -1,0 +1,39 @@
+# How to Create a cloud run service account
+
+This is aimed at the service account which is used in Form generation currently done by a cloud run service.
+
+## Variables and examples
+
+| Variable | Example |
+| -------- | ------- |
+|[SERVICE_ACCOUNT] | doc-generator-dev-sa |
+|[PROJECT_ID] | doc-generator-dev |
+|[BUCKET] | doc-generator-dev.firebasestorage.app |
+
+## Step-by-Step Instructions
+
+1. **Select project** using something like `make use-dev`
+2. **Create service account** by running:
+    ```
+    gcloud iam service-accounts create [SERVICE_ACCOUNT] \
+        --display-name="Document Generator Service Account" \
+        --project=[PROJECT_ID]
+    ```
+3. **Grant role** `roles/datastore.user` to the service account:
+    ```
+    gcloud projects add-iam-policy-binding [PROJECT_ID] \
+        --member="serviceAccount:[SERVICE_ACCOUNT]@[PROJECT_ID].iam.gserviceaccount.com" \
+        --role="roles/datastore.user"
+    ```
+4. **Grant role** `roles/storage.objectAdmin` to the service account:
+    ```
+    gcloud projects add-iam-policy-binding [PROJECT_ID] \
+        --member="serviceAccount:[SERVICE_ACCOUNT]@[PROJECT_ID].iam.gserviceaccount.com" \
+        --role="roles/storage.objectAdmin"
+    ```
+5. **Limit role** `roles/storage.objectAdmin` to the system's bucket:
+    ```
+    gsutil iam ch \
+        serviceAccount:[SERVICE_ACCOUNT]@[PROJECT_ID].iam.gserviceaccount.com:objectAdmin \
+        gs://[BUCKET]
+    ```

--- a/docs/readme/requirements/README.md
+++ b/docs/readme/requirements/README.md
@@ -14,11 +14,53 @@ The `.env` file must define the `DOCGEN_URL` environment variable.
 
 Format:
 
-```
-DOCGEN_URL=<Cloud Run URL>
-```
+    DOCGEN_URL=<Cloud Run URL>
 
 Sample:
-```
-DOCGEN_URL=https://doc-generator-612198340033.us-central1.run.app
-```
+    `DOCGEN_URL=https://doc-generator-612198340033.us-central1.run.app`
+
+## handle_firestore_event
+
+### Description
+
+Receives a request from the `process_document_job` cloud function which includes a formId.
+Creates .pdf and .docx files based on the form and the template and stores it in Firestore.
+
+### Requirements
+
+1. The deployment environment (local, GitHub actions, etc.) must define the following environment variables:
+    ```
+    DOC_TEMPLATE_FIREBASE_BUCKET_DEV
+    SA_DOC_GENERATOR_DEV
+    ```
+
+    Format:
+    ```
+    DOC_TEMPLATE_FIREBASE_BUCKET_DEV=doc-template-front-dev.firebasestorage.app
+    SA_DOC_GENERATOR_DEV=doc-generator-sa@doc-template-front-dev.iam.gserviceaccount.com
+    ```
+
+2. The cloud run service requires a Service Account with the following roles:
+    ```
+    roles/datastore.user
+    roles/storage.objectAdmin
+    ```
+
+    Example:
+    ```
+    gcloud iam service-accounts create [SERVICE_ACCOUNT] \
+    --display-name="Document Generator Service Account" \
+    --project=[PROJECT_ID]
+
+    gcloud projects add-iam-policy-binding [PROJECT_ID] \
+    --member="serviceAccount:[SERVICE_ACCOUNT]@[PROJECT_ID].iam.gserviceaccount.com" \
+    --role="roles/datastore.user"
+
+    gcloud projects add-iam-policy-binding [PROJECT_ID] \
+    --member="serviceAccount:[SERVICE_ACCOUNT]@[PROJECT_ID].iam.gserviceaccount.com" \
+    --role="roles/storage.objectAdmin"
+
+    gsutil iam ch \
+    serviceAccount:[SERVICE_ACCOUNT]@[PROJECT_ID].iam.gserviceaccount.com:objectAdmin \
+    gs://[BUCKET]
+    ```


### PR DESCRIPTION
Fixes #23 

# Changes

- Refresh service account and bucket names
- Add parameters to service account and bucket used in Makefile targets