### PR TITLE
Create prod var for cloud run deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,19 @@ DEPLOY_TARGET_DEV = dev
 PYTHON := python3
 PIP := pip3
 
+# Usage: make deploy-cloudrun ENV=prod
+ENV ?= dev  # Default to dev
+
+ifeq ($(ENV),prod)
+	PROJECT := $(PROD_PROJECT)
+	SA_DOC_GENERATOR := $(SA_DOC_GENERATOR_PROD)
+	DOC_TEMPLATE_FIREBASE_BUCKET := $(DOC_TEMPLATE_FIREBASE_BUCKET_PROD)
+else
+	PROJECT := $(DEV_PROJECT)
+	SA_DOC_GENERATOR := $(SA_DOC_GENERATOR_DEV)
+	DOC_TEMPLATE_FIREBASE_BUCKET := $(DOC_TEMPLATE_FIREBASE_BUCKET_DEV)
+endif
+
 # Environment setup
 .PHONY: use-prod use-dev
 use-prod:
@@ -46,7 +59,7 @@ build-functions: check-env
 
 build-cloudrun:
 	@echo "Building cloud run service..."
-	gcloud builds submit --tag gcr.io/${DEV_PROJECT}/doc-generator cloud-run/.
+	gcloud builds submit --tag gcr.io/${PROJECT}/doc-generator cloud-run/.
 
 # Deployment commands
 .PHONY: deploy-prod deploy-dev deploy-functions deploy-rules deploy-cloudrun
@@ -90,13 +103,13 @@ deploy-rules:
 deploy-cloudrun: build-cloudrun
 	@echo " Deploying cloud run service..."
 	gcloud run deploy doc-generator \
-	--image=gcr.io/${DEV_PROJECT}/doc-generator \
-	--service-account=${SA_DOC_GENERATOR_DEV} \
+	--image=gcr.io/${PROJECT}/doc-generator \
+	--service-account=${SA_DOC_GENERATOR} \
 	--no-allow-unauthenticated \
 	--platform=managed \
 	--region=us-central1 \
 	--set-env-vars="JAVA_TOOL_OPTIONS=-Djava.awt.headless=true" \
-	--set-env-vars=OUTPUT_BUCKET=${DOC_TEMPLATE_FIREBASE_BUCKET_DEV}
+	--set-env-vars=OUTPUT_BUCKET=${DOC_TEMPLATE_FIREBASE_BUCKET}
 
 # Serve locally
 .PHONY: serve-prod serve-dev serve-dev-emulators
@@ -153,23 +166,24 @@ check-env:
 .PHONY: help
 help:
 	@echo "Available commands:"
-	@echo "  make install           	- Install dependencies"
-	@echo "  make build-prod        	- Build production version"
-	@echo "  make build-dev         	- Build development version"
-	@echo "  make build-functions   	- Build cloud functions"
-	@echo "  make build-cloudrun    	- Build cloud run service"
-	@echo "  make deploy-prod       	- Deploy to production"
-	@echo "  make deploy-dev        	- Deploy to dev"
-	@echo "  make deploy-functions  	- Deploy all cloud functions"
-	@echo "  make deploy-ts-functions  	- Deploy TypeScript cloud functions"
-	@echo "  make deploy-py-functions  	- Deploy Python cloud functions"
-	@echo "  make deploy-rules	    	- Deploy firestore rules"
-	@echo "  make deploy-cloudrun   	- Deploy cloud run service"
-	@echo "  make serve             	- Start local dev server"
-	@echo "  make serve-prod        	- Serve production build locally"
-	@echo "  make serve-dev         	- Serve dev build locally"
-	@echo "  make clean             	- Remove build artifacts"
-	@echo "  make use-prod          	- Switch to production Firebase project"
-	@echo "  make use-dev           	- Switch to dev Firebase project"
-	@echo "  make run-emulators     	- Run emulators for dev"
-	@echo "  make export-data       	- Export data from emulators"
+	@echo "  make install           			- Install dependencies"
+	@echo "  make build-prod        			- Build production version"
+	@echo "  make build-dev         			- Build development version"
+	@echo "  make build-functions   			- Build cloud functions"
+	@echo "  make build-cloudrun    			- Build cloud run service"
+	@echo "  make deploy-prod       			- Deploy to production"
+	@echo "  make deploy-dev        			- Deploy to dev"
+	@echo "  make deploy-functions  			- Deploy all cloud functions"
+	@echo "  make deploy-ts-functions  			- Deploy TypeScript cloud functions"
+	@echo "  make deploy-py-functions  			- Deploy Python cloud functions"
+	@echo "  make deploy-rules	    			- Deploy firestore rules"
+	@echo "  make deploy-cloudrun ENV=dev  		- Deploy cloud run service to dev"
+	@echo "  make deploy-cloudrun ENV=prod  	- Deploy cloud run service to prod"
+	@echo "  make serve             			- Start local dev server"
+	@echo "  make serve-prod        			- Serve production build locally"
+	@echo "  make serve-dev         			- Serve dev build locally"
+	@echo "  make clean             			- Remove build artifacts"
+	@echo "  make use-prod          			- Switch to production Firebase project"
+	@echo "  make use-dev           			- Switch to dev Firebase project"
+	@echo "  make run-emulators     			- Run emulators for dev"
+	@echo "  make export-data       			- Export data from emulators"

--- a/cloud-run/firestore_utils.py
+++ b/cloud-run/firestore_utils.py
@@ -108,6 +108,7 @@ def generate_signed_url(blob_path: str, expiration_hours: int = 1) -> str:
         allowed_origins=[
             "http://localhost:5173",
             "https://doc-template-front-dev.web.app"
+            "https://doc-template-front.web.app"
         ]
     )
     return url

--- a/docs/readme/howto/how-to-create-cloudrun-service-account/README.md
+++ b/docs/readme/howto/how-to-create-cloudrun-service-account/README.md
@@ -1,4 +1,4 @@
-# How to Create a cloud run service account
+# How to Create a cloud run service
 
 This is aimed at the service account which is used in Form generation currently done by a cloud run service.
 
@@ -10,7 +10,18 @@ This is aimed at the service account which is used in Form generation currently 
 |[PROJECT_ID] | doc-generator-dev |
 |[BUCKET] | doc-generator-dev.firebasestorage.app |
 
-## Step-by-Step Instructions
+## Create artifact registry repository - Step-by-Step Instructions
+
+1. **Select project** using something like `make use-dev`
+2. **Create artifact registry repository** by running:
+    ```
+    gcloud artifacts repositories create cloud-run-repo \
+        --repository-format=docker \
+        --location=us-central1 \
+        --description="Docker repository for Cloud Run"
+    ```
+
+## Create service account - Step-by-Step Instructions
 
 1. **Select project** using something like `make use-dev`
 2. **Create service account** by running:


### PR DESCRIPTION
Fixes #27 

# Changes

- Add parameters to most of the Makefile targets
e.g. Instead of running `make build-prod` or `make build-dev` we now do `make build-frontend ENV=prod` or `make build-frontend ENV=dev`
- Added the prod website as an allowed origin for cloud functions requests
- Improved README